### PR TITLE
Add Next.js portfolio scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# portfolio
+# Portfolio
+
+This repository contains a simple Next.js portfolio project with Tailwind CSS.

--- a/my-portfolio-app/.eslintrc.json
+++ b/my-portfolio-app/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next"
+}

--- a/my-portfolio-app/components/Navbar.tsx
+++ b/my-portfolio-app/components/Navbar.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+const sections = [
+  { id: 'about', label: 'About Me' },
+  { id: 'experience', label: 'Experience' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'contact', label: 'Contact' },
+]
+
+export default function Navbar() {
+  return (
+    <nav className="fixed top-0 w-full bg-white shadow z-10">
+      <div className="max-w-4xl mx-auto flex space-x-4 p-4">
+        {sections.map((sec) => (
+          <Link key={sec.id} href={`#${sec.id}`} className="hover:underline">
+            {sec.label}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  )
+}

--- a/my-portfolio-app/next-env.d.ts
+++ b/my-portfolio-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/my-portfolio-app/next.config.js
+++ b/my-portfolio-app/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/my-portfolio-app/package.json
+++ b/my-portfolio-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "my-portfolio-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.12",
+    "postcss": "^8.4.18",
+    "tailwindcss": "^3.1.8",
+    "eslint": "^8.23.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "^5.2.0"
+  }
+}

--- a/my-portfolio-app/pages/_app.tsx
+++ b/my-portfolio-app/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/my-portfolio-app/pages/index.tsx
+++ b/my-portfolio-app/pages/index.tsx
@@ -1,0 +1,32 @@
+import Head from 'next/head'
+import Navbar from '../components/Navbar'
+
+export default function Home() {
+  return (
+    <div>
+      <Head>
+        <title>My Portfolio</title>
+        <meta name="description" content="Portfolio" />
+      </Head>
+      <Navbar />
+      <main className="max-w-4xl mx-auto pt-16 space-y-24 p-4">
+        <section id="about" className="min-h-screen flex flex-col justify-center">
+          <h1 className="text-4xl font-bold mb-4">About Me</h1>
+          <p className="text-lg">This is a short bio about me.</p>
+        </section>
+        <section id="experience" className="min-h-screen flex flex-col justify-center">
+          <h2 className="text-3xl font-bold mb-4">Experience</h2>
+          <p className="text-lg">My work history goes here.</p>
+        </section>
+        <section id="skills" className="min-h-screen flex flex-col justify-center">
+          <h2 className="text-3xl font-bold mb-4">Skills</h2>
+          <p className="text-lg">React, Next.js, TailwindCSS, and more.</p>
+        </section>
+        <section id="contact" className="min-h-screen flex flex-col justify-center">
+          <h2 className="text-3xl font-bold mb-4">Contact</h2>
+          <p className="text-lg">Feel free to reach out via email.</p>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/my-portfolio-app/postcss.config.js
+++ b/my-portfolio-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/my-portfolio-app/styles/globals.css
+++ b/my-portfolio-app/styles/globals.css
@@ -1,0 +1,6 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+html {
+  scroll-behavior: smooth;
+}

--- a/my-portfolio-app/tailwind.config.js
+++ b/my-portfolio-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/my-portfolio-app/tsconfig.json
+++ b/my-portfolio-app/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize a Next.js project with Tailwind CSS
- add navigation bar component
- implement single-page sections for About, Experience, Skills, and Contact
- update repository README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af91847448329b9c5b9125ea5fba3